### PR TITLE
Fix server and client channels data race

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -283,13 +283,8 @@ func (c *CqlClientConnection) outgoingLoop() {
 	go func() {
 		abort := false
 		for !abort && !c.IsClosed() {
-			if outgoing, ok := <-c.outgoing; !ok {
-				if !c.IsClosed() {
-					log.Error().Msgf("%v: outgoing frame channel was closed unexpectedly, closing connection", c)
-					abort = true
-				}
-				break
-			} else {
+			select {
+			case outgoing := <-c.outgoing:
 				log.Debug().Msgf("%v: sending outgoing frame: %v", c, outgoing)
 				if c.modernLayout {
 					// TODO write coalescer
@@ -297,6 +292,10 @@ func (c *CqlClientConnection) outgoingLoop() {
 				} else {
 					abort = c.writeFrame(outgoing, c.conn)
 				}
+			case <-c.ctx.Done():
+				log.Error().Msgf("%v: outgoing frame channel was closed unexpectedly, closing connection", c)
+				abort = true
+
 			}
 		}
 		c.waitGroup.Done()
@@ -580,11 +579,10 @@ func (c *CqlClientConnection) ReceiveEvent() (*frame.Frame, error) {
 		return nil, fmt.Errorf("%v: connection closed", c)
 	}
 	select {
-	case incoming, ok := <-c.events:
-		if !ok {
-			return nil, fmt.Errorf("%v: incoming events channel closed", c)
-		}
+	case incoming := <-c.events:
 		return incoming, nil
+	case <-c.ctx.Done():
+		return nil, fmt.Errorf("%v: connection closed", c)
 	case <-time.After(c.readTimeout):
 		return nil, fmt.Errorf("%v: timed out waiting for incoming events", c)
 	}
@@ -603,8 +601,6 @@ func (c *CqlClientConnection) Close() (err error) {
 		log.Debug().Msgf("%v: closing", c)
 		c.cancel()
 		err = c.conn.Close()
-		close(c.outgoing)
-		close(c.events)
 		c.inFlightHandler.close()
 		c.waitGroup.Wait()
 		if err != nil {

--- a/client/client.go
+++ b/client/client.go
@@ -293,12 +293,10 @@ func (c *CqlClientConnection) outgoingLoop() {
 					abort = c.writeFrame(outgoing, c.conn)
 				}
 			case <-c.ctx.Done():
-				log.Error().Msgf("%v: outgoing frame channel was closed unexpectedly, closing connection", c)
-				abort = true
-
 			}
 		}
 		c.waitGroup.Done()
+		log.Debug().Msgf("%v: stopping listening for outgoing frames", c)
 		if abort {
 			c.abort()
 		}

--- a/client/server.go
+++ b/client/server.go
@@ -504,11 +504,10 @@ func (c *CqlServerConnection) outgoingLoop() {
 					}
 				}
 			case <-c.ctx.Done():
-				log.Error().Msgf("%v: outgoing frame channel was closed unexpectedly, closing connection", c)
-				abort = true
 			}
 		}
 		c.waitGroup.Done()
+		log.Debug().Msgf("%v: stopping listening for outgoing frames", c)
 		if abort {
 			c.abort()
 		}
@@ -754,6 +753,7 @@ func (c *CqlServerConnection) Receive() (*frame.Frame, error) {
 	log.Debug().Msgf("%v: waiting for incoming frame", c)
 	select {
 	case incoming := <-c.incoming:
+		log.Debug().Msgf("%v: incoming frame successfully received: %v", c, incoming)
 		return incoming, nil
 	case <-c.ctx.Done():
 		return nil, fmt.Errorf("%v: connection closed", c)

--- a/client/server.go
+++ b/client/server.go
@@ -486,13 +486,8 @@ func (c *CqlServerConnection) outgoingLoop() {
 	go func() {
 		abort := false
 		for !c.IsClosed() {
-			if outgoing, ok := <-c.outgoing; !ok {
-				if !c.IsClosed() {
-					log.Error().Msgf("%v: outgoing frame channel was closed unexpectedly, closing connection", c)
-					abort = true
-				}
-				break
-			} else {
+			select {
+			case outgoing := <-c.outgoing:
 				if outgoing.rawResponse != nil {
 					abort = c.writeRawResponse(outgoing.rawResponse, c.conn)
 					log.Debug().Msgf("%v: sending outgoing raw response: %v", c, outgoing.rawResponse)
@@ -508,6 +503,9 @@ func (c *CqlServerConnection) outgoingLoop() {
 						abort = c.writeFrame(outgoing.responseFrame, c.conn)
 					}
 				}
+			case <-c.ctx.Done():
+				log.Error().Msgf("%v: outgoing frame channel was closed unexpectedly, closing connection", c)
+				abort = true
 			}
 		}
 		c.waitGroup.Done()
@@ -754,15 +752,11 @@ func (c *CqlServerConnection) Receive() (*frame.Frame, error) {
 		return nil, fmt.Errorf("%v: connection closed", c)
 	}
 	log.Debug().Msgf("%v: waiting for incoming frame", c)
-	if incoming, ok := <-c.incoming; !ok {
-		if c.IsClosed() {
-			return nil, fmt.Errorf("%v: connection closed", c)
-		} else {
-			return nil, fmt.Errorf("%v: incoming frame channel closed unexpectedly", c)
-		}
-	} else {
-		log.Debug().Msgf("%v: incoming frame successfully received: %v", c, incoming)
+	select {
+	case incoming := <-c.incoming:
 		return incoming, nil
+	case <-c.ctx.Done():
+		return nil, fmt.Errorf("%v: connection closed", c)
 	}
 }
 
@@ -779,8 +773,6 @@ func (c *CqlServerConnection) Close() (err error) {
 		log.Debug().Msgf("%v: closing", c)
 		c.cancel()
 		err = c.conn.Close()
-		close(c.incoming)
-		close(c.outgoing)
 		c.waitGroup.Wait()
 		c.onClose(c)
 		if err != nil {

--- a/client/server_test.go
+++ b/client/server_test.go
@@ -16,12 +16,15 @@ package client_test
 
 import (
 	"context"
+	"testing"
+	"time"
+
 	"github.com/datastax/go-cassandra-native-protocol/client"
+	"github.com/datastax/go-cassandra-native-protocol/frame"
+	"github.com/datastax/go-cassandra-native-protocol/message"
 	"github.com/datastax/go-cassandra-native-protocol/primitive"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
-	"time"
 )
 
 func TestCqlServer_Accept(t *testing.T) {
@@ -220,4 +223,44 @@ func TestCqlServer_BindAndInit(t *testing.T) {
 	assert.Eventually(t, serverConn1.IsClosed, time.Second*10, time.Millisecond*10)
 	assert.Eventually(t, serverConn2.IsClosed, time.Second*10, time.Millisecond*10)
 	assert.Eventually(t, server.IsClosed, time.Second*10, time.Millisecond*10)
+}
+
+// TestCqlConnectionRace ensures there is no data race and invalid memory access
+// during the server and client connections teardown.
+//
+// Run with this test with data race detector enabled.
+// Example: `go test ./client/ -race -count=100 -run=TestCqlConnectionRace`
+func TestCqlConnectionRace(t *testing.T) {
+	srv := client.NewCqlServer("127.0.0.1:9043", nil)
+	t.Cleanup(func() {
+		srv.Close()
+	})
+	clt := client.NewCqlClient("127.0.0.1:9043", nil)
+
+	require.NoError(t, srv.Start(t.Context()))
+
+	// Connect to the server and start the incomingLoop and outgoingLoop.
+	conn, srvConn, err := srv.BindAndInit(clt, t.Context(), primitive.ProtocolVersion4, client.ManagedStreamId)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		conn.Close()
+		srvConn.Close()
+	})
+
+	// Perform a send to guarantee the loops are already running.
+	_, err = conn.Send(frame.NewFrame(
+		primitive.ProtocolVersion4,
+		client.ManagedStreamId,
+		&message.Query{
+			Query:   "SELECT * FROM system.local",
+			Options: &message.QueryOptions{},
+		},
+	))
+	require.NoError(t, err)
+
+	// Close the server connection, this will cause the client loops to abort
+	// and clean up resources. This is where it will usually trigger a data race
+	// as both connections still using some of the channels.
+	require.NoError(t, srv.Close())
+	require.NoError(t, srvConn.Close())
 }


### PR DESCRIPTION
In some scenarios, the connections would close before the `incoming` and `outgoing` loops were done. This could trigger a data race warning or even a panic (trying to write into a closed channel).

This PR updates the code on both clients to avoid closing the channel and rely on context cancellation to exit the loops.

<details>
<summary>Example data race that can happen</summary>

```
==================
WARNING: DATA RACE
Write at 0x00c000164a90 by goroutine 495:
  runtime.recvDirect()
      /go/1.24.4/libexec/src/runtime/chan.go:405 +0x7c
  github.com/datastax/go-cassandra-native-protocol/client.(*CqlServerConnection).Close()
      /go-cassandra-native-protocol/client/server.go:783 +0x12c
  github.com/datastax/go-cassandra-native-protocol/client.(*clientConnectionHandler).close()
      /go-cassandra-native-protocol/client/connection.go:159 +0x1d8
  github.com/datastax/go-cassandra-native-protocol/client.(*CqlServer).Close()
      /go-cassandra-native-protocol/client/server.go:193 +0xf8
  github.com/datastax/go-cassandra-native-protocol/client_test.TestCqlConnectionRace()
      /go-cassandra-native-protocol/client/server_test.go:294 +0x65c
  testing.tRunner()
      /go/1.24.4/libexec/src/testing/testing.go:1792 +0x180
  testing.(*T).Run.gowrap1()
      /go/1.24.4/libexec/src/testing/testing.go:1851 +0x40

Previous read at 0x00c000164a90 by goroutine 509:
  runtime.chansend1()
      /go/1.24.4/libexec/src/runtime/chan.go:162 +0x2c
  github.com/datastax/go-cassandra-native-protocol/client.(*CqlServerConnection).Send()
      /go-cassandra-native-protocol/client/server.go:727 +0x168
  github.com/datastax/go-cassandra-native-protocol/client_test.TestCqlConnectionRace.func3.1()
      /go-cassandra-native-protocol/client/server_test.go:276 +0x3c0
  github.com/stretchr/testify/assert.didPanic.func1()
      /go/pkg/mod/github.com/stretchr/testify@v1.7.0/assert/assertions.go:1018 +0x9c
  github.com/stretchr/testify/assert.didPanic()
      /go/pkg/mod/github.com/stretchr/testify@v1.7.0/assert/assertions.go:1020 +0x40
  github.com/stretchr/testify/assert.NotPanics()
      /go/pkg/mod/github.com/stretchr/testify@v1.7.0/assert/assertions.go:1091 +0x78
  github.com/datastax/go-cassandra-native-protocol/client_test.TestCqlConnectionRace.func3()
      /go-cassandra-native-protocol/client/server_test.go:269 +0xf4

Goroutine 495 (running) created at:
  testing.(*T).Run()
      /go/1.24.4/libexec/src/testing/testing.go:1851 +0x684
  testing.runTests.func1()
      /go/1.24.4/libexec/src/testing/testing.go:2279 +0x7c
  testing.tRunner()
      /go/1.24.4/libexec/src/testing/testing.go:1792 +0x180
  testing.runTests()
      /go/1.24.4/libexec/src/testing/testing.go:2277 +0x77c
  testing.(*M).Run()
      /go/1.24.4/libexec/src/testing/testing.go:2142 +0xb68
  github.com/datastax/go-cassandra-native-protocol/client_test.TestMain()
      /go-cassandra-native-protocol/client/main_test.go:37 +0x208
  main.main()
      _testmain.go:97 +0x114

Goroutine 509 (finished) created at:
  github.com/datastax/go-cassandra-native-protocol/client_test.TestCqlConnectionRace()
      /go-cassandra-native-protocol/client/server_test.go:267 +0x654
  testing.tRunner()
      /go/1.24.4/libexec/src/testing/testing.go:1792 +0x180
  testing.(*T).Run.gowrap1()
      /go/1.24.4/libexec/src/testing/testing.go:1851 +0x40
==================
```
</details>
