### PR TITLE
Fix WaitGroup data races

### DIFF
--- a/client/server.go
+++ b/client/server.go
@@ -115,11 +115,12 @@ type CqlServer struct {
 	connectionsHandler *clientConnectionHandler
 	waitGroup          *sync.WaitGroup
 	state              int32
+	abort              func() error
 }
 
 // NewCqlServer creates a new CqlServer with default options. Leave credentials nil to opt out from authentication.
 func NewCqlServer(listenAddress string, credentials *AuthCredentials) *CqlServer {
-	return &CqlServer{
+	srv := &CqlServer{
 		ListenAddress:  listenAddress,
 		Credentials:    credentials,
 		MaxConnections: DefaultMaxConnections,
@@ -127,6 +128,14 @@ func NewCqlServer(listenAddress string, credentials *AuthCredentials) *CqlServer
 		AcceptTimeout:  DefaultAcceptTimeout,
 		IdleTimeout:    DefaultIdleTimeout,
 	}
+	srv.abort = sync.OnceValue(func() error {
+		srv.transitionState(ServerStateRunning, ServerStateClosed)
+		err := srv.Listener.Close()
+		srv.connectionsHandler.close()
+		srv.cancel()
+		return err
+	})
+	return srv
 }
 
 func (server *CqlServer) String() string {
@@ -177,20 +186,8 @@ func (server *CqlServer) Start(ctx context.Context) (err error) {
 		}
 		server.ctx, server.cancel = context.WithCancel(ctx)
 		server.waitGroup = &sync.WaitGroup{}
-		// We must ensure the waitGroup counter is added before the goroutines
-		// start given that they use `abort` function, which performs `wg.Wait`
-		// call (leading to potential data races).
-		server.waitGroup.Add(2)
-		go func() {
-			server.acceptLoop()
-			server.waitGroup.Done()
-			server.abort()
-		}()
-		go func() {
-			server.awaitDone()
-			server.waitGroup.Done()
-			server.abort()
-		}()
+		server.waitGroup.Go(server.acceptLoop)
+		server.waitGroup.Go(server.awaitDone)
 		log.Info().Msgf("%v: successfully started", server)
 	} else {
 		log.Debug().Msgf("%v: already started or closed", server)
@@ -199,29 +196,21 @@ func (server *CqlServer) Start(ctx context.Context) (err error) {
 }
 
 func (server *CqlServer) Close() (err error) {
-	if server.transitionState(ServerStateRunning, ServerStateClosed) {
-		log.Debug().Msgf("%v: closing", server)
-		err = server.Listener.Close()
-		server.connectionsHandler.close()
-		server.cancel()
-		server.waitGroup.Wait()
-		if err != nil {
-			log.Debug().Err(err).Msgf("%v: could not close server", server)
-			err = fmt.Errorf("%v: could not close server: %w", server, err)
-		} else {
-			log.Info().Msgf("%v: successfully closed", server)
-		}
-	} else {
+	if server.IsClosed() || server.IsNotStarted() {
 		log.Debug().Msgf("%v: not started or already closed", server)
+		return nil
+	}
+
+	log.Debug().Msgf("%v: closing", server)
+	err = server.abort()
+	server.waitGroup.Wait()
+	if err != nil {
+		log.Debug().Err(err).Msgf("%v: could not close server", server)
+		err = fmt.Errorf("%v: could not close server: %w", server, err)
+	} else {
+		log.Info().Msgf("%v: successfully closed", server)
 	}
 	return err
-}
-
-func (server *CqlServer) abort() {
-	log.Debug().Msgf("%v: forcefully closing", server)
-	if err := server.Close(); err != nil {
-		log.Error().Err(err).Msgf("%v: error closing", server)
-	}
 }
 
 func (server *CqlServer) acceptLoop() {
@@ -232,7 +221,6 @@ func (server *CqlServer) acceptLoop() {
 				log.Error().Err(err).Msgf("%v: error accepting client connections, closing server", server)
 				abort = true
 			}
-			break
 		} else {
 			log.Debug().Msgf("%v: new TCP connection accepted", server)
 			if connection, err := newCqlServerConnection(
@@ -255,10 +243,14 @@ func (server *CqlServer) acceptLoop() {
 			}
 		}
 	}
+	if abort {
+		_ = server.abort()
+	}
 }
 
 func (server *CqlServer) awaitDone() {
 	<-server.ctx.Done()
+	server.abort()
 	log.Debug().Err(server.ctx.Err()).Msgf("%v: context was closed", server)
 }
 
@@ -384,6 +376,7 @@ type CqlServerConnection struct {
 	ctx                context.Context
 	cancel             context.CancelFunc
 	payloadAccumulator *payloadAccumulator
+	abort              func() error
 }
 
 func newCqlServerConnection(
@@ -425,30 +418,17 @@ func newCqlServerConnection(
 		connection.handlerCtx[i] = requestHandlerContext{}
 	}
 	connection.ctx, connection.cancel = context.WithCancel(ctx)
+	connection.abort = sync.OnceValue(func() error {
+		connection.setClosed()
+		connection.cancel()
+		err := connection.conn.Close()
+		connection.onClose(connection)
+		return err
+	})
 
-	// Ensure the wait group counter is set before starting the goroutines since
-	// they can abort the connection, causing wg.Wait() to be called before all
-	// wg.Add were called (leading to a data race).
-	//
-	// We cannot use wg.Go given that the abort call must only happen after
-	// wg.Done is called.
-	connection.waitGroup.Add(3)
-	go func() {
-		connection.incomingLoop()
-		connection.waitGroup.Done()
-		connection.abort()
-	}()
-	go func() {
-		connection.outgoingLoop()
-		connection.waitGroup.Done()
-		connection.abort()
-	}()
-	go func() {
-		connection.awaitDone()
-		connection.waitGroup.Done()
-		connection.abort()
-	}()
-
+	connection.waitGroup.Go(connection.incomingLoop)
+	connection.waitGroup.Go(connection.outgoingLoop)
+	connection.waitGroup.Go(connection.awaitDone)
 	return connection, nil
 }
 
@@ -481,7 +461,7 @@ func (c *CqlServerConnection) GetConn() net.Conn {
 func (c *CqlServerConnection) incomingLoop() {
 	log.Debug().Msgf("%v: listening for incoming frames...", c)
 	abort := false
-	for !abort && !c.IsClosed() {
+	for !c.IsClosed() && !abort {
 		if abort = c.setIdleTimeout(); !abort {
 			if source, err := c.waitForIncomingData(); err != nil {
 				abort = c.reportConnectionFailure(err, true)
@@ -492,12 +472,15 @@ func (c *CqlServerConnection) incomingLoop() {
 			}
 		}
 	}
+	if abort {
+		_ = c.abort()
+	}
 }
 
 func (c *CqlServerConnection) outgoingLoop() {
 	log.Debug().Msgf("%v: listening for outgoing frames...", c)
 	abort := false
-	for !abort && !c.IsClosed() {
+	for !c.IsClosed() && !abort {
 		select {
 		case outgoing := <-c.outgoing:
 			if outgoing.rawResponse != nil {
@@ -519,6 +502,9 @@ func (c *CqlServerConnection) outgoingLoop() {
 		}
 	}
 	log.Debug().Msgf("%v: stopping listening for outgoing frames", c)
+	if abort {
+		c.abort()
+	}
 }
 
 func (c *CqlServerConnection) waitForIncomingData() (io.Reader, error) {
@@ -679,6 +665,7 @@ func (c *CqlServerConnection) processIncomingFrame(incoming *frame.Frame) {
 
 func (c *CqlServerConnection) awaitDone() {
 	<-c.ctx.Done()
+	c.abort()
 	log.Debug().Err(c.ctx.Err()).Msgf("%v: context was closed", c)
 }
 
@@ -767,28 +754,20 @@ func (c *CqlServerConnection) setClosed() bool {
 }
 
 func (c *CqlServerConnection) Close() (err error) {
-	if c.setClosed() {
-		log.Debug().Msgf("%v: closing", c)
-		c.cancel()
-		err = c.conn.Close()
-		c.waitGroup.Wait()
-		c.onClose(c)
-		if err != nil {
-			err = fmt.Errorf("%v: error closing: %w", c, err)
-		} else {
-			log.Info().Msgf("%v: successfully closed", c)
-		}
-	} else {
+	if c.IsClosed() {
 		log.Debug().Err(err).Msgf("%v: already closed", c)
+		return nil
+	}
+
+	log.Debug().Msgf("%v: closing", c)
+	err = c.abort()
+	c.waitGroup.Wait()
+	if err != nil {
+		err = fmt.Errorf("%v: error closing: %w", c, err)
+	} else {
+		log.Info().Msgf("%v: successfully closed", c)
 	}
 	return err
-}
-
-func (c *CqlServerConnection) abort() {
-	log.Debug().Msgf("%v: forcefully closing", c)
-	if err := c.Close(); err != nil {
-		log.Error().Err(err).Msgf("%v: error closing", c)
-	}
 }
 
 func init() {

--- a/client/server.go
+++ b/client/server.go
@@ -177,8 +177,20 @@ func (server *CqlServer) Start(ctx context.Context) (err error) {
 		}
 		server.ctx, server.cancel = context.WithCancel(ctx)
 		server.waitGroup = &sync.WaitGroup{}
-		server.acceptLoop()
-		server.awaitDone()
+		// We must ensure the waitGroup counter is added before the goroutines
+		// start given that they use `abort` function, which performs `wg.Wait`
+		// call (leading to potential data races).
+		server.waitGroup.Add(2)
+		go func() {
+			server.acceptLoop()
+			server.waitGroup.Done()
+			server.abort()
+		}()
+		go func() {
+			server.awaitDone()
+			server.waitGroup.Done()
+			server.abort()
+		}()
 		log.Info().Msgf("%v: successfully started", server)
 	} else {
 		log.Debug().Msgf("%v: already started or closed", server)
@@ -213,53 +225,41 @@ func (server *CqlServer) abort() {
 }
 
 func (server *CqlServer) acceptLoop() {
-	server.waitGroup.Add(1)
-	go func() {
-		abort := false
-		for server.IsRunning() {
-			if conn, err := server.Listener.Accept(); err != nil {
-				if !server.IsClosed() {
-					log.Error().Err(err).Msgf("%v: error accepting client connections, closing server", server)
-					abort = true
-				}
-				break
+	abort := false
+	for server.IsRunning() && !abort {
+		if conn, err := server.Listener.Accept(); err != nil {
+			if !server.IsClosed() {
+				log.Error().Err(err).Msgf("%v: error accepting client connections, closing server", server)
+				abort = true
+			}
+			break
+		} else {
+			log.Debug().Msgf("%v: new TCP connection accepted", server)
+			if connection, err := newCqlServerConnection(
+				conn,
+				server.ctx,
+				server.Credentials,
+				server.MaxInFlight,
+				server.IdleTimeout,
+				server.RequestHandlers,
+				server.RequestRawHandlers,
+				server.connectionsHandler.onConnectionClosed,
+			); err != nil {
+				log.Error().Msgf("%v: failed to accept incoming CQL client connection: %v", server, connection)
+				_ = conn.Close()
+			} else if err := server.connectionsHandler.onConnectionAccepted(connection); err != nil {
+				log.Error().Msgf("%v: handler rejected incoming CQL client connection: %v", server, connection)
+				_ = conn.Close()
 			} else {
-				log.Debug().Msgf("%v: new TCP connection accepted", server)
-				if connection, err := newCqlServerConnection(
-					conn,
-					server.ctx,
-					server.Credentials,
-					server.MaxInFlight,
-					server.IdleTimeout,
-					server.RequestHandlers,
-					server.RequestRawHandlers,
-					server.connectionsHandler.onConnectionClosed,
-				); err != nil {
-					log.Error().Msgf("%v: failed to accept incoming CQL client connection: %v", server, connection)
-					_ = conn.Close()
-				} else if err := server.connectionsHandler.onConnectionAccepted(connection); err != nil {
-					log.Error().Msgf("%v: handler rejected incoming CQL client connection: %v", server, connection)
-					_ = conn.Close()
-				} else {
-					log.Info().Msgf("%v: accepted new incoming CQL client connection: %v", server, connection)
-				}
+				log.Info().Msgf("%v: accepted new incoming CQL client connection: %v", server, connection)
 			}
 		}
-		server.waitGroup.Done()
-		if abort {
-			server.abort()
-		}
-	}()
+	}
 }
 
 func (server *CqlServer) awaitDone() {
-	server.waitGroup.Add(1)
-	go func() {
-		<-server.ctx.Done()
-		log.Debug().Err(server.ctx.Err()).Msgf("%v: context was closed", server)
-		server.waitGroup.Done()
-		server.abort()
-	}()
+	<-server.ctx.Done()
+	log.Debug().Err(server.ctx.Err()).Msgf("%v: context was closed", server)
 }
 
 // Accept waits until the given client address is accepted, the configured timeout is triggered, or the server is
@@ -425,9 +425,30 @@ func newCqlServerConnection(
 		connection.handlerCtx[i] = requestHandlerContext{}
 	}
 	connection.ctx, connection.cancel = context.WithCancel(ctx)
-	connection.incomingLoop()
-	connection.outgoingLoop()
-	connection.awaitDone()
+
+	// Ensure the wait group counter is set before starting the goroutines since
+	// they can abort the connection, causing wg.Wait() to be called before all
+	// wg.Add were called (leading to a data race).
+	//
+	// We cannot use wg.Go given that the abort call must only happen after
+	// wg.Done is called.
+	connection.waitGroup.Add(3)
+	go func() {
+		connection.incomingLoop()
+		connection.waitGroup.Done()
+		connection.abort()
+	}()
+	go func() {
+		connection.outgoingLoop()
+		connection.waitGroup.Done()
+		connection.abort()
+	}()
+	go func() {
+		connection.awaitDone()
+		connection.waitGroup.Done()
+		connection.abort()
+	}()
+
 	return connection, nil
 }
 
@@ -459,59 +480,45 @@ func (c *CqlServerConnection) GetConn() net.Conn {
 
 func (c *CqlServerConnection) incomingLoop() {
 	log.Debug().Msgf("%v: listening for incoming frames...", c)
-	c.waitGroup.Add(1)
-	go func() {
-		abort := false
-		for !abort && !c.IsClosed() {
-			if abort = c.setIdleTimeout(); !abort {
-				if source, err := c.waitForIncomingData(); err != nil {
-					abort = c.reportConnectionFailure(err, true)
-				} else if c.modernLayout {
-					abort = c.readSegment(source)
-				} else {
-					abort = c.readFrame(source)
-				}
+	abort := false
+	for !abort && !c.IsClosed() {
+		if abort = c.setIdleTimeout(); !abort {
+			if source, err := c.waitForIncomingData(); err != nil {
+				abort = c.reportConnectionFailure(err, true)
+			} else if c.modernLayout {
+				abort = c.readSegment(source)
+			} else {
+				abort = c.readFrame(source)
 			}
 		}
-		c.waitGroup.Done()
-		if abort {
-			c.abort()
-		}
-	}()
+	}
 }
 
 func (c *CqlServerConnection) outgoingLoop() {
 	log.Debug().Msgf("%v: listening for outgoing frames...", c)
-	c.waitGroup.Add(1)
-	go func() {
-		abort := false
-		for !c.IsClosed() {
-			select {
-			case outgoing := <-c.outgoing:
-				if outgoing.rawResponse != nil {
-					abort = c.writeRawResponse(outgoing.rawResponse, c.conn)
-					log.Debug().Msgf("%v: sending outgoing raw response: %v", c, outgoing.rawResponse)
-				} else {
-					if c.compression != primitive.CompressionNone {
-						outgoing.responseFrame.Header.Flags = outgoing.responseFrame.Header.Flags.Add(primitive.HeaderFlagCompressed)
-					}
-					log.Debug().Msgf("%v: sending outgoing frame: %v", c, outgoing.responseFrame)
-					if c.modernLayout {
-						// TODO write coalescer
-						abort = c.writeSegment(outgoing.responseFrame, c.conn)
-					} else {
-						abort = c.writeFrame(outgoing.responseFrame, c.conn)
-					}
+	abort := false
+	for !abort && !c.IsClosed() {
+		select {
+		case outgoing := <-c.outgoing:
+			if outgoing.rawResponse != nil {
+				abort = c.writeRawResponse(outgoing.rawResponse, c.conn)
+				log.Debug().Msgf("%v: sending outgoing raw response: %v", c, outgoing.rawResponse)
+			} else {
+				if c.compression != primitive.CompressionNone {
+					outgoing.responseFrame.Header.Flags = outgoing.responseFrame.Header.Flags.Add(primitive.HeaderFlagCompressed)
 				}
-			case <-c.ctx.Done():
+				log.Debug().Msgf("%v: sending outgoing frame: %v", c, outgoing.responseFrame)
+				if c.modernLayout {
+					// TODO write coalescer
+					abort = c.writeSegment(outgoing.responseFrame, c.conn)
+				} else {
+					abort = c.writeFrame(outgoing.responseFrame, c.conn)
+				}
 			}
+		case <-c.ctx.Done():
 		}
-		c.waitGroup.Done()
-		log.Debug().Msgf("%v: stopping listening for outgoing frames", c)
-		if abort {
-			c.abort()
-		}
-	}()
+	}
+	log.Debug().Msgf("%v: stopping listening for outgoing frames", c)
 }
 
 func (c *CqlServerConnection) waitForIncomingData() (io.Reader, error) {
@@ -666,52 +673,43 @@ func (c *CqlServerConnection) processIncomingFrame(incoming *frame.Frame) {
 		log.Error().Msgf("%v: incoming frames queue is full, discarding frame: %v", c, incoming)
 	}
 	if len(c.handlers) > 0 {
-		c.invokeRequestHandlers(incoming)
+		c.waitGroup.Go(func() { c.invokeRequestHandlers(incoming) })
 	}
 }
 
 func (c *CqlServerConnection) awaitDone() {
-	c.waitGroup.Add(1)
-	go func() {
-		<-c.ctx.Done()
-		log.Debug().Err(c.ctx.Err()).Msgf("%v: context was closed", c)
-		c.waitGroup.Done()
-		c.abort()
-	}()
+	<-c.ctx.Done()
+	log.Debug().Err(c.ctx.Err()).Msgf("%v: context was closed", c)
 }
 
 func (c *CqlServerConnection) invokeRequestHandlers(request *frame.Frame) {
-	c.waitGroup.Add(1)
-	go func() {
-		log.Debug().Msgf("%v: invoking request handlers for incoming request: %v", c, request)
-		var err error
-		var rawResponse []byte
-		for i, rawHandler := range c.rawHandlers {
-			if rawResponse = rawHandler(request, c, c.handlerCtx[i]); rawResponse != nil {
-				log.Debug().Msgf("%v: raw request handler %v produced response: %v", c, i, rawResponse)
-				if err = c.SendRaw(rawResponse); err != nil {
-					log.Error().Err(err).Msgf("%v: send failed for frame: %v", c, rawResponse)
+	log.Debug().Msgf("%v: invoking request handlers for incoming request: %v", c, request)
+	var err error
+	var rawResponse []byte
+	for i, rawHandler := range c.rawHandlers {
+		if rawResponse = rawHandler(request, c, c.handlerCtx[i]); rawResponse != nil {
+			log.Debug().Msgf("%v: raw request handler %v produced response: %v", c, i, rawResponse)
+			if err = c.SendRaw(rawResponse); err != nil {
+				log.Error().Err(err).Msgf("%v: send failed for frame: %v", c, rawResponse)
+			}
+			break
+		}
+	}
+	if rawResponse == nil {
+		var response *frame.Frame
+		for i, handler := range c.handlers {
+			if response = handler(request, c, c.handlerCtx[i]); response != nil {
+				log.Debug().Msgf("%v: request handler %v produced response: %v", c, i, response)
+				if err = c.Send(response); err != nil {
+					log.Error().Err(err).Msgf("%v: send failed for frame: %v", c, response)
 				}
 				break
 			}
 		}
-		if rawResponse == nil {
-			var response *frame.Frame
-			for i, handler := range c.handlers {
-				if response = handler(request, c, c.handlerCtx[i]); response != nil {
-					log.Debug().Msgf("%v: request handler %v produced response: %v", c, i, response)
-					if err = c.Send(response); err != nil {
-						log.Error().Err(err).Msgf("%v: send failed for frame: %v", c, response)
-					}
-					break
-				}
-			}
-			if response == nil {
-				log.Debug().Msgf("%v: no request handler could handle the request: %v", c, request)
-			}
+		if response == nil {
+			log.Debug().Msgf("%v: no request handler could handle the request: %v", c, request)
 		}
-		c.waitGroup.Done()
-	}()
+	}
 }
 
 // Send sends the given response frame.

--- a/client/server_test.go
+++ b/client/server_test.go
@@ -12,14 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package client_test
+package client
 
 import (
 	"context"
+	"errors"
+	"net"
 	"testing"
 	"time"
 
-	"github.com/datastax/go-cassandra-native-protocol/client"
+	// "github.com/datastax/go-cassandra-native-protocol/client"
 	"github.com/datastax/go-cassandra-native-protocol/frame"
 	"github.com/datastax/go-cassandra-native-protocol/message"
 	"github.com/datastax/go-cassandra-native-protocol/primitive"
@@ -29,10 +31,10 @@ import (
 
 func TestCqlServer_Accept(t *testing.T) {
 
-	server := client.NewCqlServer("127.0.0.1:9043", nil)
+	server := NewCqlServer("127.0.0.1:9043", nil)
 
-	clt1 := client.NewCqlClient("127.0.0.1:9043", nil)
-	clt2 := client.NewCqlClient("127.0.0.1:9043", nil)
+	clt1 := NewCqlClient("127.0.0.1:9043", nil)
+	clt2 := NewCqlClient("127.0.0.1:9043", nil)
 
 	ctx, cancelFn := context.WithCancel(context.Background())
 
@@ -71,10 +73,10 @@ func TestCqlServer_Accept(t *testing.T) {
 
 func TestCqlServer_AcceptAny(t *testing.T) {
 
-	server := client.NewCqlServer("127.0.0.1:9043", nil)
+	server := NewCqlServer("127.0.0.1:9043", nil)
 
-	clt1 := client.NewCqlClient("127.0.0.1:9043", nil)
-	clt2 := client.NewCqlClient("127.0.0.1:9043", nil)
+	clt1 := NewCqlClient("127.0.0.1:9043", nil)
+	clt2 := NewCqlClient("127.0.0.1:9043", nil)
 
 	ctx, cancelFn := context.WithCancel(context.Background())
 
@@ -113,10 +115,10 @@ func TestCqlServer_AcceptAny(t *testing.T) {
 
 func TestCqlServer_AllAcceptedClients(t *testing.T) {
 
-	server := client.NewCqlServer("127.0.0.1:9043", nil)
+	server := NewCqlServer("127.0.0.1:9043", nil)
 
-	clt1 := client.NewCqlClient("127.0.0.1:9043", nil)
-	clt2 := client.NewCqlClient("127.0.0.1:9043", nil)
+	clt1 := NewCqlClient("127.0.0.1:9043", nil)
+	clt2 := NewCqlClient("127.0.0.1:9043", nil)
 
 	ctx, cancelFn := context.WithCancel(context.Background())
 
@@ -155,10 +157,10 @@ func TestCqlServer_AllAcceptedClients(t *testing.T) {
 
 func TestCqlServer_Bind(t *testing.T) {
 
-	server := client.NewCqlServer("127.0.0.1:9043", nil)
+	server := NewCqlServer("127.0.0.1:9043", nil)
 
-	clt1 := client.NewCqlClient("127.0.0.1:9043", nil)
-	clt2 := client.NewCqlClient("127.0.0.1:9043", nil)
+	clt1 := NewCqlClient("127.0.0.1:9043", nil)
+	clt2 := NewCqlClient("127.0.0.1:9043", nil)
 
 	ctx, cancelFn := context.WithCancel(context.Background())
 
@@ -191,17 +193,17 @@ func TestCqlServer_Bind(t *testing.T) {
 
 func TestCqlServer_BindAndInit(t *testing.T) {
 
-	server := client.NewCqlServer("127.0.0.1:9043", nil)
+	server := NewCqlServer("127.0.0.1:9043", nil)
 
-	clt1 := client.NewCqlClient("127.0.0.1:9043", nil)
-	clt2 := client.NewCqlClient("127.0.0.1:9043", nil)
+	clt1 := NewCqlClient("127.0.0.1:9043", nil)
+	clt2 := NewCqlClient("127.0.0.1:9043", nil)
 
 	ctx, cancelFn := context.WithCancel(context.Background())
 
 	err := server.Start(ctx)
 	require.NoError(t, err)
 
-	clientConn1, serverConn1, err := server.BindAndInit(clt1, ctx, primitive.ProtocolVersion4, client.ManagedStreamId)
+	clientConn1, serverConn1, err := server.BindAndInit(clt1, ctx, primitive.ProtocolVersion4, ManagedStreamId)
 	require.NoError(t, err)
 	require.NotNil(t, clientConn1)
 	require.NotNil(t, serverConn1)
@@ -231,16 +233,16 @@ func TestCqlServer_BindAndInit(t *testing.T) {
 // Run with this test with data race detector enabled.
 // Example: `go test ./client/ -race -count=100 -run=TestCqlConnectionRace`
 func TestCqlConnectionRace(t *testing.T) {
-	srv := client.NewCqlServer("127.0.0.1:9043", nil)
+	srv := NewCqlServer("127.0.0.1:9043", nil)
 	t.Cleanup(func() {
 		srv.Close()
 	})
-	clt := client.NewCqlClient("127.0.0.1:9043", nil)
+	clt := NewCqlClient("127.0.0.1:9043", nil)
 
 	require.NoError(t, srv.Start(t.Context()))
 
 	// Connect to the server and start the incomingLoop and outgoingLoop.
-	conn, srvConn, err := srv.BindAndInit(clt, t.Context(), primitive.ProtocolVersion4, client.ManagedStreamId)
+	conn, srvConn, err := srv.BindAndInit(clt, t.Context(), primitive.ProtocolVersion4, ManagedStreamId)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		conn.Close()
@@ -250,7 +252,7 @@ func TestCqlConnectionRace(t *testing.T) {
 	// Perform a send to guarantee the loops are already running.
 	_, err = conn.Send(frame.NewFrame(
 		primitive.ProtocolVersion4,
-		client.ManagedStreamId,
+		ManagedStreamId,
 		&message.Query{
 			Query:   "SELECT * FROM system.local",
 			Options: &message.QueryOptions{},
@@ -263,4 +265,68 @@ func TestCqlConnectionRace(t *testing.T) {
 	// as both connections still using some of the channels.
 	require.NoError(t, srv.Close())
 	require.NoError(t, srvConn.Close())
+}
+
+// TestNewCqlServerConnectionRace ensures there is no data race during the
+// server connection setup.
+//
+// Run with: go test -race -count=10000 -run TestNewCqlServerConnectionRace
+func TestNewCqlServerConnectionRace(t *testing.T) {
+	conn := &failingConn{}
+
+	serverConn, err := newCqlServerConnection(
+		conn,
+		t.Context(),
+		nil, /* credentials */
+		128,
+		time.Hour,
+		nil, /* rawHandlers */
+		nil, /* onClose */
+		func(*CqlServerConnection) {},
+	)
+	if err != nil {
+		// Connection creation might fail, that's expected
+		return
+	}
+	if serverConn != nil {
+		_ = serverConn.Close()
+	}
+}
+
+// failingConn is a net.Conn that fails immediately on read operations.
+// This represents a connection that fails during the initial handshake.
+type failingConn struct {
+	net.Conn
+}
+
+func (f *failingConn) Read(b []byte) (n int, err error) {
+	return 0, errors.New("connection failure")
+}
+
+func (f *failingConn) Write(b []byte) (n int, err error) {
+	return len(b), nil
+}
+
+func (f *failingConn) Close() error {
+	return nil
+}
+
+func (f *failingConn) LocalAddr() net.Addr {
+	return &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 9042}
+}
+
+func (f *failingConn) RemoteAddr() net.Addr {
+	return &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 12345}
+}
+
+func (f *failingConn) SetDeadline(t time.Time) error {
+	return nil
+}
+
+func (f *failingConn) SetReadDeadline(t time.Time) error {
+	return nil
+}
+
+func (f *failingConn) SetWriteDeadline(t time.Time) error {
+	return nil
 }

--- a/client/server_test.go
+++ b/client/server_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 	"time"
 
-	// "github.com/datastax/go-cassandra-native-protocol/client"
 	"github.com/datastax/go-cassandra-native-protocol/frame"
 	"github.com/datastax/go-cassandra-native-protocol/message"
 	"github.com/datastax/go-cassandra-native-protocol/primitive"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/datastax/go-cassandra-native-protocol
 
-go 1.17
+go 1.25
 
 require (
 	github.com/golang/snappy v0.0.3


### PR DESCRIPTION
Before this change, there was a short window in which `incomingLoop` would exit (by calling `abort`) before the other goroutines (`outgoingLoop` and `awaitDone`) started. This would cause a data race, since `abort` would call `wg.Wait` before all `wg.Add` calls (from two other goroutines).

This PR solves this by calling `wg.Add` beforehand and ensuring that `wg.Done` is called before `abort` (to avoid potential deadlocks). There is also an additional test used to reproduce the data race violation.

Note for reviewers: Since this change only affects Teleport tests, the goal was to keep it as small as possible and avoid any other refactor outside the issue being fixed. There is no intention of pushing this into mainstream, as it is no longer maintained.